### PR TITLE
Bug Fix Sidebar & Header

### DIFF
--- a/src/app/employee/add-leave/add-leave.component.ts
+++ b/src/app/employee/add-leave/add-leave.component.ts
@@ -4,6 +4,7 @@ import {Router} from '@angular/router';
 import {LeaveService} from '../../shared-data/leaveapplication.service';
 import {CurrentUserService} from '../../shared-data/currentUserService';
 import {PaginatedLeaveApplication} from '../../shared-data/paginated-leave-application';
+import {UsersService} from '../../shared-data/users.service';
 
 @Component({
   selector: 'app-employee-add-leave',
@@ -24,7 +25,8 @@ export class EmployeeAddLeaveComponent implements OnInit {
   constructor(
     private readonly router: Router,
     private readonly leaveService: LeaveService,
-    private readonly currentUserService: CurrentUserService
+    private readonly currentUserService: CurrentUserService,
+    private readonly usersService: UsersService
   ) {
     const user = this.currentUserService.getCurrentUser();
     this.availableLeave = user?.remainingCredits ?? 0;
@@ -57,10 +59,23 @@ export class EmployeeAddLeaveComponent implements OnInit {
     const startDate = new Date(start);
     const endDate = new Date(end);
 
-    const diff =
-      Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    if (endDate < startDate) {
+      this.leaveForm.get('totalDays')?.setValue(0);
+      return;
+    }
 
-    this.leaveForm.get('totalDays')?.setValue(diff > 0 ? diff : 0);
+    let days = 0;
+    let current = new Date(startDate);
+
+    while (current <= endDate) {
+      const dayOfWeek = current.getDay();
+      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+        days++;
+      }
+      current.setDate(current.getDate() + 1);
+    }
+
+    this.leaveForm.get('totalDays')?.setValue(days);
   }
 
   saveLeaveApplication() {
@@ -81,8 +96,12 @@ export class EmployeeAddLeaveComponent implements OnInit {
             console.log('Leave request submitted:', response);
             alert('Leave request submitted successfully!');
 
-            // update available leave immediately in UI
             this.availableLeave = Math.max(this.availableLeave - totalDays, 0);
+
+            this.usersService.getUserById(user.id).subscribe(updatedUser => {
+              this.currentUserService.setCurrentUser(updatedUser); // update global state
+              this.availableLeave = updatedUser.remainingCredits ?? 0;
+            });
 
             // reset form
             this.leaveForm.reset({totalDays: 0});

--- a/src/app/employee/add-leave/add-leave.component.ts
+++ b/src/app/employee/add-leave/add-leave.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, effect, OnInit} from '@angular/core';
 import {FormControl, FormGroup, FormsModule, ReactiveFormsModule, Validators} from '@angular/forms';
 import {Router} from '@angular/router';
 import {LeaveService} from '../../shared-data/leaveapplication.service';
@@ -37,14 +37,18 @@ export class EmployeeAddLeaveComponent implements OnInit {
       totalDays: new FormControl(0, Validators.required),
       remarks: new FormControl('', [Validators.required, Validators.minLength(5)])
     });
+
+    effect(() => {
+      const user = this.currentUserService.getCurrentUser();
+      if (user) {
+        this.availableLeave = user.remainingCredits;
+      }
+    });
   }
 
   ngOnInit() {
     this.leaveForm.get('startDate')?.valueChanges.subscribe(() => this.calculateTotalDays());
     this.leaveForm.get('endDate')?.valueChanges.subscribe(() => this.calculateTotalDays());
-
-    const user = this.currentUserService.getCurrentUser();
-    this.availableLeave = user?.remainingCredits ?? 0;
   }
 
   calculateTotalDays() {

--- a/src/app/employee/my-leave/my-leave.component.ts
+++ b/src/app/employee/my-leave/my-leave.component.ts
@@ -25,7 +25,7 @@ export class EmployeeMyLeaveComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (user) {
       this.loadLeaves(user.id);
     }
@@ -49,11 +49,14 @@ export class EmployeeMyLeaveComponent implements OnInit {
   }
 
   cancel(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.cancelLeave(user.id, leaveId).subscribe({
-      next: () => this.loadLeaves(user.id),
+      next: () => {
+        this.loadLeaves(user.id);
+        this.currentUserService.refreshCurrentUser(user.id);
+      },
       error: (err: any) => console.error('Failed to cancel leave:', err)
     });
   }

--- a/src/app/hr/view-all-leaves/view-all-leaves.component.ts
+++ b/src/app/hr/view-all-leaves/view-all-leaves.component.ts
@@ -28,7 +28,7 @@ export class HRViewAllLeavesComponent implements OnInit {
   }
 
   ngOnInit() {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (user) {
       this.loadAllLeaves(user.id);
     }
@@ -52,7 +52,7 @@ export class HRViewAllLeavesComponent implements OnInit {
   }
 
   approve(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.approveLeave(user.id, leaveId).subscribe({
@@ -62,7 +62,7 @@ export class HRViewAllLeavesComponent implements OnInit {
   }
 
   reject(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.rejectLeave(user.id, leaveId).subscribe({

--- a/src/app/manager/add-leave/add-leave.component.ts
+++ b/src/app/manager/add-leave/add-leave.component.ts
@@ -1,4 +1,4 @@
-import {Component, OnInit} from '@angular/core';
+import {Component, effect, OnInit} from '@angular/core';
 import { Router } from '@angular/router';
 import { ReactiveFormsModule, FormGroup, FormControl, Validators } from '@angular/forms';
 import { CommonModule } from '@angular/common';
@@ -34,14 +34,18 @@ export class ManagerAddLeaveComponent implements OnInit{
       totalDays: new FormControl(0, Validators.required),
       remarks: new FormControl('', [Validators.required, Validators.minLength(5)])
     });
+
+    effect(() => {
+      const user = this.currentUserService.getCurrentUser();
+      if (user) {
+        this.availableLeave = user.remainingCredits;
+      }
+    });
   }
 
   ngOnInit() {
     this.leaveForm.get('startDate')?.valueChanges.subscribe(() => this.calculateTotalDays());
     this.leaveForm.get('endDate')?.valueChanges.subscribe(() => this.calculateTotalDays());
-
-    const user = this.currentUserService.getCurrentUser();
-    this.availableLeave = user?.remainingCredits ?? 0;
   }
 
   calculateTotalDays() {

--- a/src/app/manager/add-leave/add-leave.component.ts
+++ b/src/app/manager/add-leave/add-leave.component.ts
@@ -5,6 +5,7 @@ import { CommonModule } from '@angular/common';
 import { LeaveService } from '../../shared-data/leaveapplication.service';
 import { CurrentUserService } from '../../shared-data/currentUserService';
 import { PaginatedLeaveApplication } from '../../shared-data/paginated-leave-application';
+import {UsersService} from '../../shared-data/users.service';
 
 @Component({
   selector: 'app-manager-add-leave',
@@ -21,7 +22,8 @@ export class ManagerAddLeaveComponent implements OnInit{
   constructor(
     private readonly router: Router,
     private readonly leaveService: LeaveService,
-    private readonly currentUserService: CurrentUserService
+    private readonly currentUserService: CurrentUserService,
+    private readonly usersService: UsersService
   ) {
     const user = this.currentUserService.getCurrentUser();
     this.availableLeave = user?.remainingCredits ?? 0;
@@ -54,12 +56,24 @@ export class ManagerAddLeaveComponent implements OnInit{
     const startDate = new Date(start);
     const endDate = new Date(end);
 
-    const diff =
-      Math.floor((endDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    if (endDate < startDate) {
+      this.leaveForm.get('totalDays')?.setValue(0);
+      return;
+    }
 
-    this.leaveForm.get('totalDays')?.setValue(diff > 0 ? diff : 0);
+    let days = 0;
+    let current = new Date(startDate);
+
+    while (current <= endDate) {
+      const dayOfWeek = current.getDay();
+      if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+        days++;
+      }
+      current.setDate(current.getDate() + 1);
+    }
+
+    this.leaveForm.get('totalDays')?.setValue(days);
   }
-
   saveLeaveApplication() {
     if (this.leaveForm.valid) {
       const totalDays = this.leaveForm.get('totalDays')?.value;
@@ -80,6 +94,11 @@ export class ManagerAddLeaveComponent implements OnInit{
 
             // update available leave immediately in UI
             this.availableLeave = Math.max(this.availableLeave - totalDays, 0);
+
+            this.usersService.getUserById(user.id).subscribe(updatedUser => {
+              this.currentUserService.setCurrentUser(updatedUser); // update global state
+              this.availableLeave = updatedUser.remainingCredits ?? 0;
+            });
 
             // reset form
             this.leaveForm.reset({ totalDays: 0 });

--- a/src/app/manager/view-employee-leave/employee-leave.component.ts
+++ b/src/app/manager/view-employee-leave/employee-leave.component.ts
@@ -18,7 +18,7 @@ import {Router} from '@angular/router';
 export class ManagerViewEmployeeLeaveComponent implements OnInit{
   leaves: LeaveApplication[] = [];
   currentPage = 1;
-  itemsPerPage = 5;
+  itemsPerPage = 15;
   totalPages = 0;
   loading = false;
 
@@ -30,7 +30,7 @@ export class ManagerViewEmployeeLeaveComponent implements OnInit{
 ) {}
 
   ngOnInit() {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (user) {
       this.loadTeamLeaves(user.id);
     }
@@ -54,26 +54,25 @@ export class ManagerViewEmployeeLeaveComponent implements OnInit{
   }
 
   approve(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.approveLeave(user.id, leaveId).subscribe({
       next: () => {
         this.loadTeamLeaves(user.id)
-        this.router.navigate(['manager/view-employee-leave']);
       },
       error: (err: any) => console.error('Failed to approve leave:', err)
     });
   }
 
   reject(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.rejectLeave(user.id, leaveId).subscribe({
-      next: () => {
-        this.loadTeamLeaves(user.id)
-        this.router.navigate(['manager/view-employee-leave']);
+      next: (updatedLeave: LeaveApplication) => {
+        this.loadTeamLeaves(user.id);
+        this.currentUserService.refreshCurrentUser(updatedLeave.employeeId);
       },
       error: (err: any) => console.error('Failed to reject leave:', err)
     });

--- a/src/app/manager/view-leave/view-leave.component.ts
+++ b/src/app/manager/view-leave/view-leave.component.ts
@@ -29,7 +29,7 @@ export class ManagerViewLeaveComponent implements OnInit{
   ) {}
 
   ngOnInit() {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (user) {
       this.loadLeaves(user.id);
     }
@@ -53,13 +53,13 @@ export class ManagerViewLeaveComponent implements OnInit{
   }
 
   cancel(leaveId: number) {
-    const user = this.currentUserService.currentUser();
+    const user = this.currentUserService.getCurrentUser();
     if (!user) return;
 
     this.leaveService.cancelLeave(user.id, leaveId).subscribe({
       next: () => {
         this.loadLeaves(user.id);
-        this.router.navigate(['manager/view-leave']);
+        this.currentUserService.refreshCurrentUser(user.id);
       },
       error: (err: any) => console.error('Failed to cancel leave:', err)
     });

--- a/src/app/shared-components/sidebar/sidebar.component.html
+++ b/src/app/shared-components/sidebar/sidebar.component.html
@@ -1,5 +1,5 @@
 <aside class="sidebar">
-  <div class="user-info" *ngIf="currentUserService.currentUser() as selectedUser">
+  <div class="user-info" *ngIf="currentUserService.getCurrentUser() as selectedUser">
 <!--    <p>{{ selectedUser.name }}</p>-->
 <!--    <p>{{ selectedUser.role }}</p>-->
   </div>

--- a/src/app/shared-components/sidebar/sidebar.component.ts
+++ b/src/app/shared-components/sidebar/sidebar.component.ts
@@ -28,7 +28,6 @@ export class SidebarComponent {
       const user = this.currentUserService.getCurrentUser();
       this.menuItems = this.buildMenu(user);
 
-      // 👇 if there’s at least one menu with children, set the first one active
       const firstChild = this.menuItems[0]?.children?.[0];
       if (firstChild) {
         this.activeItem = firstChild.label;

--- a/src/app/shared-components/sidebar/sidebar.component.ts
+++ b/src/app/shared-components/sidebar/sidebar.component.ts
@@ -25,7 +25,7 @@ export class SidebarComponent {
     private router: Router
   ) {
     effect(() => {
-      const user = this.currentUserService.currentUser();
+      const user = this.currentUserService.getCurrentUser();
       this.menuItems = this.buildMenu(user);
 
       // 👇 if there’s at least one menu with children, set the first one active

--- a/src/app/shared-data/currentUserService.ts
+++ b/src/app/shared-data/currentUserService.ts
@@ -1,11 +1,15 @@
 import { Injectable, signal, WritableSignal } from '@angular/core';
 import { User } from './paginated-users';
+import {UsersService} from './users.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class CurrentUserService {
-  currentUser: WritableSignal<User | undefined> = signal<User | undefined>(undefined);
+
+  private currentUser: WritableSignal<User | undefined> = signal<User | undefined>(undefined);
+
+  constructor(private usersService: UsersService) {}
 
   setCurrentUser(user: User) {
     this.currentUser.set(user);
@@ -14,4 +18,11 @@ export class CurrentUserService {
   getCurrentUser(): User | undefined {
     return this.currentUser();
   }
-}
+
+  refreshCurrentUser(userId: number) {
+    this.usersService.getUserById(userId).subscribe({
+      next: (updatedUser) => this.setCurrentUser(updatedUser),
+      error: (err) => console.error('Failed to refresh current user:', err)
+    });
+  }
+  }

--- a/src/app/shared-data/leaveapplication.service.ts
+++ b/src/app/shared-data/leaveapplication.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-import {LeaveApplicationRequestBody, PaginatedLeaveApplication} from './paginated-leave-application';
+import {LeaveApplication, LeaveApplicationRequestBody, PaginatedLeaveApplication} from './paginated-leave-application';
 
 @Injectable({ providedIn: 'root' })
 export class LeaveService {
@@ -31,7 +31,7 @@ export class LeaveService {
   }
 
   rejectLeave(userId: number, leaveId: number) {
-    return this.http.patch(`${this.apiUrl}/${userId}/${leaveId}/reject`, {});
+    return this.http.patch<LeaveApplication>(`${this.apiUrl}/${userId}/${leaveId}/reject`, {});
   }
 
   cancelLeave(userId: number, leaveId: number) {

--- a/src/app/shared-data/paginated-leave-application.ts
+++ b/src/app/shared-data/paginated-leave-application.ts
@@ -4,6 +4,7 @@ export interface PaginatedLeaveApplication {
   content: LeaveApplication[];
 }
 export interface LeaveApplication {
+  employeeId: number;
   employeeName: string;
   id: number;
   startDate: string;


### PR DESCRIPTION
- Instead of using NgOnInit when switching between users. Change to reactive effect in the Add Leave component to automatically update availableLeave whenever the selected user changes via the header dropdown.
-This way when we switch from Employee -> Employee -> Employee on the header, the Add Leave component would always show the correct leave credits and no longer displays stale data.